### PR TITLE
Show related items of FAQ Items in FAQ view.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,14 @@ Changelog
 =========
 
 
-3.0.2 (unreleased)
+3.1.0 (unreleased)
 ------------------
+
+- Show related items of FAQ Items in FAQ view.
+  [maurits]
+
+- Modernize FAQ view to use Bootstrap accordions.
+  [maurits]
 
 - Properly enable versioning of FAQ and FAQ Item.
   [maurits]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ long_description = "\n\n".join(
 
 setup(
     name="collective.faq",
-    version="3.0.2.dev0",
+    version="3.1.0.dev0",
     description="Plone addon package for managing FAQ sections",
     long_description=long_description,
     # Get more from https://pypi.org/classifiers/

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
+        "AccessControl",
         "plone.api",
         "plone.app.textfield",
         "plone.base",

--- a/src/collective/faq/browser/faq.pt
+++ b/src/collective/faq/browser/faq.pt
@@ -46,27 +46,42 @@
                tal:repeat="item container/questions"
           >
             <tal:item define="
-                        obj item/getObject;
+                        question python:item['question'];
+                        related python:item['related'];
                       ">
               <h2 class="accordion-header">
                 <button class="accordion-button collapsed"
-                        aria-controls="faq-item-${item/UID}"
+                        aria-controls="faq-item-${question/UID}"
                         aria-expanded="false"
                         type="button"
-                        data-bs-target="#faq-item-${item/UID}"
+                        data-bs-target="#faq-item-${question/UID}"
                         data-bs-toggle="collapse"
                 >
-                  ${obj/title}
+                  ${question/title}
                 </button>
                 <p class="discreet ms-4"
-                   tal:condition="python: getattr(obj, 'detailed_question', None)"
-                >${obj/detailed_question}</p>
+                   tal:condition="python: getattr(question, 'detailed_question', None)"
+                >${question/detailed_question}</p>
               </h2>
               <div class="faq-item-answer accordion-collapse collapse"
-                   id="faq-item-${item/UID}"
+                   id="faq-item-${question/UID}"
               >
                 <div class="accordion-body">
-                  ${structure: obj/answer/output | nothing}
+                  ${structure: question/answer/output | nothing}
+                  <div class="related"
+                       tal:condition="related"
+                  >
+                    <strong class="more-information"
+                            i18n:translate=""
+                    >More information</strong>
+                    <ul class="more-information-list">
+                      <li class="more-information-item"
+                          tal:repeat="rel related"
+                      >
+                        <a href="${rel/absolute_url}">${rel/Title}</a>
+                      </li>
+                    </ul>
+                  </div>
                 </div>
               </div>
             </tal:item>


### PR DESCRIPTION
Related items already get shown when viewing an FAQ Item.  But normally you only view the FAQ list.  So I thought it would be good to show the related items there, if available:

<img width="843" height="624" alt="Screenshot 2025-10-29 at 20 00 10" src="https://github.com/user-attachments/assets/4642eed3-89b3-41b8-871c-9a7fd4d06507" />

Initially I showed the description as well, and did not use an `<ul><li>` construction, but I think this can become a bit much, so I prefer not to:

<img width="848" height="615" alt="Screenshot 2025-10-29 at 19 35 18" src="https://github.com/user-attachments/assets/6f471b85-074d-4fd0-9ffd-52f30633b040" />
